### PR TITLE
Allow collection names in Pipelines

### DIFF
--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -11,6 +11,7 @@ Symbol.add_key(:and, "$and", "$and")
 Symbol.add_key(:nor, "$nor", "$nor")
 Symbol.add_key(:or, "$or", "$or")
 Symbol.add_key(:filter, "$filter", "$filter")
+Symbol.add_key(:if_null, "$ifNull", "$ifNull")
 
 # The base module for the gem under which all classes are namespaced.
 module Aggregate

--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -12,6 +12,7 @@ Symbol.add_key(:nor, "$nor", "$nor")
 Symbol.add_key(:or, "$or", "$or")
 Symbol.add_key(:filter, "$filter", "$filter")
 Symbol.add_key(:if_null, "$ifNull", "$ifNull")
+Symbol.add_key(:cond, "$cond", "$cond")
 
 # The base module for the gem under which all classes are namespaced.
 module Aggregate

--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -13,6 +13,7 @@ Symbol.add_key(:or, "$or", "$or")
 Symbol.add_key(:filter, "$filter", "$filter")
 Symbol.add_key(:if_null, "$ifNull", "$ifNull")
 Symbol.add_key(:cond, "$cond", "$cond")
+Symbol.add_key(:set_difference, "$setDifference", "$setDifference")
 
 # The base module for the gem under which all classes are namespaced.
 module Aggregate

--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -10,6 +10,7 @@ require "origin"
 Symbol.add_key(:and, "$and", "$and")
 Symbol.add_key(:nor, "$nor", "$nor")
 Symbol.add_key(:or, "$or", "$or")
+Symbol.add_key(:filter, "$filter", "$filter")
 
 # The base module for the gem under which all classes are namespaced.
 module Aggregate

--- a/lib/aggregate/contracts/collection_exists.rb
+++ b/lib/aggregate/contracts/collection_exists.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Aggregate
+  module Contracts
+    # Validates that a class includes a given module
+    class CollectionExists < ::Contracts::Builtin::CallableClass
+      # :reek:FeatureEnvy
+      # :reek:ManualDispatch
+      def valid?(object)
+         Mongoid.default_client.collections.find { |collection| collection.name == object.to_s }.present?
+      end
+
+      def to_s
+        "Expected to mongo db to contain collection #{@collection}"
+      end
+
+      def inspect
+        to_s
+      end
+    end
+  end
+end

--- a/lib/aggregate/contracts/key_pair.rb
+++ b/lib/aggregate/contracts/key_pair.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Aggregate
+  module Contracts
+    # Validates the specified hash key=>value combination can be an OriginKey => specified types
+    class KeyPair < ::Contracts::Builtin::CallableClass
+      def initialize(*vals)
+        @range = vals[0]
+        @key_types = vals[1]
+        @value_types = vals[2]
+        @error = nil
+      end
+
+      def valid?(hash)
+        new_hash = hash.dup.slice(*hash.keys[@range])
+        new_hash.all? do |key, value|
+          @key_types.include?(key.class) && @value_types.include?(value.class)
+        end
+      end
+
+      def to_s
+        "Hash values in range #{@range} to have a key in allowed types `#{@key_types}` and value in allowed types ``#{@types}``"
+      end
+
+      def inspect
+        to_s
+      end
+    end
+  end
+end

--- a/lib/aggregate/pipeline.rb
+++ b/lib/aggregate/pipeline.rb
@@ -9,7 +9,7 @@ module Aggregate
     def initialize(klass = nil)
       @klass = klass
       raise_message = "Pipeline initializer must specify a Mongoid::Document or collection name in order to be executable"
-      raise raise_message if collection.nil?
+      raise raise_message if !klass.nil? && collection.nil?
       @stages = []
     end
 

--- a/lib/aggregate/stages/group.rb
+++ b/lib/aggregate/stages/group.rb
@@ -7,8 +7,8 @@ module Aggregate
     class Group < HashBase
       Contract And[
                    Not[C::HashValueType[0, Hash]],
-                   C::HashValueType[1..-1, Hash]
-               ]                                                                                                                         => Any
+                   C::KeyPair[1..-1, [String, Symbol, Origin::Key], [Integer, String, Hash]]
+               ] => Any
       def initialize(options)
         super(options)
       end

--- a/lib/aggregate/stages/lookup.rb
+++ b/lib/aggregate/stages/lookup.rb
@@ -7,12 +7,12 @@ module Aggregate
     class Lookup < HashBase
       Contract Or[
                    KeywordArgs[
-                       from:         C::ClassIncludes[[Mongoid::Document]],
+                       from:         Or[C::ClassIncludes[Mongoid::Document], C::CollectionExists[]],
                        as:           String,
                        localField:   String,
                        foreignField: String],
                    KeywordArgs[
-                       from:     C::ClassIncludes[[Mongoid::Document]],
+                       from:     Or[C::ClassIncludes[Mongoid::Document], C::CollectionExists[]],
                        as:       String,
                        let:      And[HashOf[Symbol, Symbol], C::HashMinLength[1]],
                        pipeline: Aggregate::Pipeline]

--- a/lib/aggregate/values/symbol.rb
+++ b/lib/aggregate/values/symbol.rb
@@ -2,7 +2,7 @@
 
 module Aggregate
   module Values
-    # Returns a string wrapped in single quotes if the value or string if a key
+    # Returns a string wrapped in single quotes if the value or string is a key
     # Additionally adds $ to the reserved aggregation operations.
     class Symbol < Base
       # rubocop:disable Layout/AlignArray

--- a/spec/aggregate/aggregation_spec.rb
+++ b/spec/aggregate/aggregation_spec.rb
@@ -3,4 +3,22 @@
 require "rails_helper"
 
 RSpec.describe Aggregate::Pipeline do
+	before do |example|
+		allow(TestDocument).to receive(:collection).and_return(double)
+	end
+
+	it "raises if klass is not a mongoid document and collection does not exist" do
+		expect{Aggregate::Pipeline.new(Object)}.to raise_error
+	end	
+
+	it "does not raise if klass is a mongoid document" do
+		expect{Aggregate::Pipeline.new(TestDocument)}.not_to raise_error
+	end
+
+	it "does not raise if string excists as a collection" do
+		collections = [double(name: "should_exist", present?: true)]
+        allow(Mongoid).to receive_message_chain(:default_client, :collections).and_return(collections)
+		expect{Aggregate::Pipeline.new("should_exist")}.not_to raise_error
+	end
+
 end

--- a/spec/aggregate/contracts/collection_exists_spec.rb
+++ b/spec/aggregate/contracts/collection_exists_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Aggregate::Contracts::CollectionExists do
+  describe "#valid?" do
+    it "is true if the collection exists" do
+      contract = Aggregate::Contracts::CollectionExists.new
+      collections = [double(name: "should_exist", present?: true)]
+      allow(Mongoid).to receive_message_chain(:default_client, :collections).and_return(collections)
+      expect(contract.valid?("should_exist")).to eq true
+    end
+    it "is false if collection does not exist" do
+contract = Aggregate::Contracts::CollectionExists.new
+      collections = [double(name: "should_exist", present?: true)]
+      allow(Mongoid).to receive_message_chain(:default_client, :collections).and_return(collections)
+      expect(contract.valid?("should_not_exist")).to eq false
+    end
+  end
+end

--- a/spec/aggregate/contracts/key_pair_spec.rb
+++ b/spec/aggregate/contracts/key_pair_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Aggregate::Contracts::KeyPair do
+  describe "#valid?" do
+    it "is true if each hash key in range is an allowed type" do
+      contract = Aggregate::Contracts::KeyPair.new(0..1, [Origin::Key, String],[String])
+      expect(contract.valid?(
+          "one" => "1",
+          Origin::Key.new("age", "$gt", "$gt") => "two")).to eq true
+    end
+    it "is false if a hash key in range is not an allowed type" do
+      contract = Aggregate::Contracts::KeyPair.new(0..2, [String],[String])
+      expect(contract.valid?(
+          "one" => "1",
+          Origin::Key.new("age", "$gt", "$gt") => "two")).to eq false
+    end
+    it "it ignores keys not in range" do
+      contract = Aggregate::Contracts::KeyPair.new(1..2, [String], [String])
+      expect(contract.valid?(
+          key: "1",
+          "a" => "two",
+          "b" => "two")).to eq true
+    end
+    it "is true if key range is not in actual supplied range" do
+      contract = Aggregate::Contracts::KeyPair.new(1..2, [String])
+      expect(contract.valid?(key: "1")).to eq true
+    end
+
+    it "is true if value in range is of the specified types" do
+      contract = Aggregate::Contracts::KeyPair.new(0..1, [String],[String, Integer])
+      expect(contract.valid?(
+          "one" => "1",
+          "two" => 1)).to eq true
+    end
+
+    it "is false if value in range is not of the specified types" do
+      contract = Aggregate::Contracts::KeyPair.new(0..1, [String], [String])
+      expect(contract.valid?(
+          "one" => "1",
+          "two" => 1)).to eq false
+    end
+
+    it "is true when values are allowed to be of multiple types" do
+      contract = Aggregate::Contracts::KeyPair.new(0..1, [String], [String, Integer])
+      expect(contract.valid?(
+          "one" => "1",
+          "two" => 1)).to eq true
+    end
+  end
+end

--- a/spec/aggregate/stages/facet_spec.rb
+++ b/spec/aggregate/stages/facet_spec.rb
@@ -3,11 +3,15 @@
 require "rails_helper"
 
 RSpec.describe Aggregate::Stages::Facet do
+  before do |example|
+    allow(TestDocument).to receive(:collection).and_return(double)
+  end
+
   describe "#transpose" do
     it "should properly format" do
       expect(Aggregate::Stages::Facet.new(
-          testa: Aggregate::Pipeline.new,
-          testb: Aggregate::Pipeline.new
+          testa: Aggregate::Pipeline.new(TestDocument),
+          testb: Aggregate::Pipeline.new(TestDocument)
         ).transpose).to eq('$facet': { 'testa': [], 'testb': [] })
     end
   end
@@ -19,15 +23,15 @@ RSpec.describe Aggregate::Stages::Facet do
     it "should not raise if values are a Pipeline" do
       expect do
         Aggregate::Stages::Facet.new(
-            testa: Aggregate::Pipeline.new,
-            testb: Aggregate::Pipeline.new
+            testa: Aggregate::Pipeline.new(TestDocument),
+            testb: Aggregate::Pipeline.new(TestDocument)
           ).transpose
       end .not_to raise_error
     end
     it "should raise if values are not a Pipeline" do
       expect do
         Aggregate::Stages::Facet.new(
-            testa: Aggregate::Pipeline.new,
+            testa: Aggregate::Pipeline.new(TestDocument),
             testb: "test"
           ).transpose
       end .to raise_error(ParamContractError)

--- a/spec/aggregate/stages/group_spec.rb
+++ b/spec/aggregate/stages/group_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Aggregate::Stages::Group do
     it "does not raise if the first key value is a string" do
       expect { Aggregate::Stages::Group.new(test: "1") }.not_to raise_error
     end
-    it "should raise if additional key values are not hashes" do
-      expect { Aggregate::Stages::Group.new(id: nil, total: 1) }.to raise_error(ParamContractError)
+    it "should raise if additional key values are not and Integer, String or Hash" do
+      expect { Aggregate::Stages::Group.new(id: nil, total: :test) }.to raise_error(ParamContractError)
     end
   end
 end

--- a/spec/aggregate/stages/lookup_spec.rb
+++ b/spec/aggregate/stages/lookup_spec.rb
@@ -3,12 +3,16 @@
 require "rails_helper"
 
 RSpec.describe Aggregate::Stages::Lookup do
+  before do |example|
+    allow(TestDocument).to receive(:collection).and_return(double)
+  end
+
   describe "#transpose" do
     it "should properly format" do
       expect(Aggregate::Stages::Lookup.new(from:     TestDocument,
                                            let:      { test: :"$_id" },
                                            as:       "test",
-                                           pipeline: Aggregate::Pipeline.new).transpose).
+                                           pipeline: Aggregate::Pipeline.new(TestDocument)).transpose).
           to eq('$lookup': { 'from': "test_documents", 'let': { 'test': "$_id" }, 'as': "test", 'pipeline': [] })
     end
   end
@@ -88,7 +92,7 @@ RSpec.describe Aggregate::Stages::Lookup do
           Aggregate::Stages::Lookup.new(from:     TestDocument,
                                         let:      { test: :test },
                                         as:       "test",
-                                        pipeline: Aggregate::Pipeline.new)
+                                        pipeline: Aggregate::Pipeline.new(TestDocument))
         end.not_to raise_error
       end
 
@@ -100,7 +104,7 @@ RSpec.describe Aggregate::Stages::Lookup do
             Aggregate::Stages::Lookup.new(from:     "should_not_exist",
                                           let:      { test: :test },
                                           as:       "test",
-                                          pipeline: Aggregate::Pipeline.new)
+                                          pipeline: Aggregate::Pipeline.new(TestDocument))
           end.to raise_error(ParamContractError)
         end
 
@@ -111,7 +115,7 @@ RSpec.describe Aggregate::Stages::Lookup do
             Aggregate::Stages::Lookup.new(from:     Object,
                                           let:      { test: :test },
                                           as:       "test",
-                                          pipeline: Aggregate::Pipeline.new)
+                                          pipeline: Aggregate::Pipeline.new(TestDocument))
           end.to raise_error(ParamContractError)
         end
       end
@@ -122,7 +126,7 @@ RSpec.describe Aggregate::Stages::Lookup do
             Aggregate::Stages::Lookup.new(from:     TestDocument,
                                           let:      "",
                                           as:       "test",
-                                          pipeline: Aggregate::Pipeline.new)
+                                          pipeline: Aggregate::Pipeline.new(TestDocument))
           end.to raise_error(ParamContractError)
         end
 
@@ -131,7 +135,7 @@ RSpec.describe Aggregate::Stages::Lookup do
             Aggregate::Stages::Lookup.new(from:     TestDocument,
                                           let:      {},
                                           as:       "test",
-                                          pipeline: Aggregate::Pipeline.new)
+                                          pipeline: Aggregate::Pipeline.new(TestDocument))
           end.to raise_error(ParamContractError)
         end
 
@@ -140,7 +144,7 @@ RSpec.describe Aggregate::Stages::Lookup do
             Aggregate::Stages::Lookup.new(from:     TestDocument,
                                           let:      { test: "" },
                                           as:       "test",
-                                          pipeline: Aggregate::Pipeline.new)
+                                          pipeline: Aggregate::Pipeline.new(TestDocument))
           end.to raise_error(ParamContractError)
         end
       end
@@ -151,7 +155,7 @@ RSpec.describe Aggregate::Stages::Lookup do
             Aggregate::Stages::Lookup.new(from:     TestDocument,
                                           let:      { test: :test },
                                           as:       1,
-                                          pipeline: Aggregate::Pipeline.new)
+                                          pipeline: Aggregate::Pipeline.new(TestDocument))
           end.to raise_error(ParamContractError)
         end
       end


### PR DESCRIPTION
PR allows collection names in place of Mongoid Document classes